### PR TITLE
Fix App Store rejection: strip pre-release suffix from Info.plist version

### DIFF
--- a/Resources/MLKitPoseDetectionCommon-Info.plist
+++ b/Resources/MLKitPoseDetectionCommon-Info.plist
@@ -21,7 +21,7 @@
 <key>CFBundlePackageType</key>
 <string>FMWK</string>
 <key>CFBundleShortVersionString</key>
-  <string>1.0.0-beta16</string>
+  <string>1.0.0</string>
 <key>CFBundleSupportedPlatforms</key>
 <array>
 <string>iPhoneOS</string>

--- a/Resources/MLKitSegmentationCommon-Info.plist
+++ b/Resources/MLKitSegmentationCommon-Info.plist
@@ -21,7 +21,7 @@
 <key>CFBundlePackageType</key>
 <string>FMWK</string>
 <key>CFBundleShortVersionString</key>
-  <string>1.0.0-beta14</string>
+  <string>1.0.0</string>
 <key>CFBundleSupportedPlatforms</key>
 <array>
 <string>iPhoneOS</string>

--- a/Resources/MLKitXenoCommon-Info.plist
+++ b/Resources/MLKitXenoCommon-Info.plist
@@ -21,7 +21,7 @@
 <key>CFBundlePackageType</key>
 <string>FMWK</string>
 <key>CFBundleShortVersionString</key>
-  <string>1.0.0-beta16</string>
+  <string>1.0.0</string>
 <key>CFBundleSupportedPlatforms</key>
 <array>
 <string>iPhoneOS</string>

--- a/scripts/update_version.rb
+++ b/scripts/update_version.rb
@@ -26,9 +26,11 @@ def parse_podfile_lock
   versions = {}
 
   # Extract version numbers from PODS section - only top-level entries
-  # Match entries like "  - MLKitCommon (12.0.0):" (with exactly 2 spaces before dash)
+  # Match entries like "  - MLKitCommon (12.0.0):" (with exactly 2 spaces before dash).
+  # Some pods (e.g. MLKitXenoCommon) use pre-release suffixes like "1.0.0-beta16";
+  # the [\d.]+ capture below intentionally drops the suffix because App Store
+  # rejects non-numeric CFBundleShortVersionString values.
   podfile_lock.scan(/^  - ([^\/\s]+)(?:\/[^\s]+)?\s+\(([^)]+)\):?/) do |name, version_str|
-    # Extract only the version number (digits and dots)
     if match = version_str.match(/([\d.]+)/)
       version = match[1]
       versions[name] = version
@@ -38,28 +40,40 @@ def parse_podfile_lock
   versions
 end
 
-# Map Info.plist filename to framework name in Podfile.lock
+# Map Info.plist filename to framework name in Podfile.lock.
+# Every Resources/<Name>-Info.plist must be listed here so update_version.rb
+# can rewrite CFBundleShortVersionString from Podfile.lock; otherwise the
+# file keeps a stale (and possibly App-Store-illegal) version string.
 PLIST_TO_FRAMEWORK = {
   'MLKitCommon-Info.plist' => 'MLKitCommon',
   'MLKitBarcodeScanning-Info.plist' => 'MLKitBarcodeScanning',
   'MLKitFaceDetection-Info.plist' => 'MLKitFaceDetection',
   'MLKitVision-Info.plist' => 'MLKitVision',
+  'MLKitVisionKit-Info.plist' => 'MLKitVisionKit',
   'MLImage-Info.plist' => 'MLImage',
   'MLKitTextRecognition-Info.plist' => 'MLKitTextRecognition',
   'MLKitTextRecognitionChinese-Info.plist' => 'MLKitTextRecognitionChinese',
   'MLKitTextRecognitionDevanagari-Info.plist' => 'MLKitTextRecognitionDevanagari',
   'MLKitTextRecognitionJapanese-Info.plist' => 'MLKitTextRecognitionJapanese',
   'MLKitTextRecognitionKorean-Info.plist' => 'MLKitTextRecognitionKorean',
+  'MLKitTextRecognitionCommon-Info.plist' => 'MLKitTextRecognitionCommon',
   'MLKitImageLabeling-Info.plist' => 'MLKitImageLabeling',
   'MLKitImageLabelingCustom-Info.plist' => 'MLKitImageLabelingCustom',
+  'MLKitImageLabelingCommon-Info.plist' => 'MLKitImageLabelingCommon',
   'MLKitObjectDetection-Info.plist' => 'MLKitObjectDetection',
   'MLKitObjectDetectionCustom-Info.plist' => 'MLKitObjectDetectionCustom',
+  'MLKitObjectDetectionCommon-Info.plist' => 'MLKitObjectDetectionCommon',
   'MLKitPoseDetection-Info.plist' => 'MLKitPoseDetection',
   'MLKitPoseDetectionAccurate-Info.plist' => 'MLKitPoseDetectionAccurate',
+  'MLKitPoseDetectionCommon-Info.plist' => 'MLKitPoseDetectionCommon',
   'MLKitSegmentationSelfie-Info.plist' => 'MLKitSegmentationSelfie',
+  'MLKitSegmentationCommon-Info.plist' => 'MLKitSegmentationCommon',
+  'MLKitXenoCommon-Info.plist' => 'MLKitXenoCommon',
+  'MLKitNaturalLanguage-Info.plist' => 'MLKitNaturalLanguage',
   'MLKitLanguageID-Info.plist' => 'MLKitLanguageID',
   'MLKitTranslate-Info.plist' => 'MLKitTranslate',
-  'MLKitSmartReply-Info.plist' => 'MLKitSmartReply'
+  'MLKitSmartReply-Info.plist' => 'MLKitSmartReply',
+  'SSZipArchive-Info.plist' => 'SSZipArchive'
 }.freeze
 
 # Update Info.plist files with versions from Podfile.lock


### PR DESCRIPTION
## Summary

- Three Info.plist templates (`MLKitPoseDetectionCommon`, `MLKitSegmentationCommon`, `MLKitXenoCommon`) shipped a `CFBundleShortVersionString` like `1.0.0-beta16` / `1.0.0-beta14`. App Store Connect rejects any non-`X.Y.Z` value, so apps that embed these XCFrameworks failed to upload.
- Reset the three values to `1.0.0` so the next release zip embeds an App-Store-legal version.
- Extended `scripts/update_version.rb` so every `Resources/*-Info.plist` (including the previously missing Common / VisionKit / NaturalLanguage / SSZipArchive entries) is rewritten from `Podfile.lock` on each version bump. The existing `[\\d.]+` capture in `parse_podfile_lock` already drops pre-release suffixes; that behavior is now documented so future MLKit bumps stay App-Store-compatible.

Addresses item (2) of #90.

Item (1) of that issue — MLKit's offline model loader resolving JSON paths from the host app's main bundle instead of the XCFramework — is a SwiftPM/MLKit interaction inside the closed-source MLKit binary; it can't be fixed in this repo and is left open in #90.

## Test plan

- [x] `swift package dump-package` (Package.swift parses)
- [x] `ruby -c scripts/update_version.rb` (script syntax OK)
- [x] Verified every file in `Resources/*-Info.plist` is now mapped in `PLIST_TO_FRAMEWORK`
- [ ] After merge: run `./scripts/build_all.sh <version>` against a current MLKit release and confirm the regenerated Info.plists contain only numeric `CFBundleShortVersionString` values
- [ ] After merge: a downstream consumer uploads to App Store Connect and is no longer rejected for pre-release version strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)