### PR TITLE
Allow SemVer pre-release suffix on wrapper release tags

### DIFF
--- a/scripts/automate_release.sh
+++ b/scripts/automate_release.sh
@@ -17,10 +17,12 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-# Validate version format
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+# Validate version format. Accept an optional SemVer pre-release suffix
+# (e.g. "9.0.0-1") so wrapper repackages can ship with a tag distinct from
+# the upstream MLKit base version.
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
   echo "Error: Invalid version format '$VERSION'"
-  echo "Expected semantic versioning format: X.Y.Z"
+  echo "Expected semantic versioning format: X.Y.Z[-PRERELEASE]"
   exit 1
 fi
 

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -15,10 +15,12 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-# Validate version format (semantic versioning: X.Y.Z)
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+# Validate version format. Accept an optional SemVer pre-release suffix
+# (e.g. "9.0.0-1") so the wrapper can publish a repackage tag that differs
+# from the upstream MLKit base version.
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
   echo "Error: Invalid version format '$VERSION'"
-  echo "Expected semantic versioning format: X.Y.Z (e.g., 1.2.3, 2.0.0)"
+  echo "Expected semantic versioning format: X.Y.Z[-PRERELEASE] (e.g., 1.2.3, 9.0.0-1)"
   exit 1
 fi
 

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -11,10 +11,12 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-# Validate version format (semantic versioning: X.Y.Z)
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+# Validate version format. Accept an optional SemVer pre-release suffix
+# (e.g. "9.0.0-1") so wrapper repackages can ship with a tag distinct from
+# the upstream MLKit base version.
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
   echo "Error: Invalid version format '$VERSION'"
-  echo "Expected semantic versioning format: X.Y.Z (e.g., 1.2.3, 2.0.0)"
+  echo "Expected semantic versioning format: X.Y.Z[-PRERELEASE] (e.g., 1.2.3, 9.0.0-1)"
   exit 1
 fi
 

--- a/scripts/generate_release_notes.rb
+++ b/scripts/generate_release_notes.rb
@@ -114,10 +114,11 @@ if __FILE__ == $PROGRAM_NAME
   version = ARGV[0]
   pod_changes_file = ARGV[1]
 
-  # Validate version format
-  unless version =~ /^\d+\.\d+\.\d+$/
+  # Validate version format. Accept an optional SemVer pre-release suffix
+  # (e.g. "9.0.0-1") for wrapper repackages.
+  unless version =~ /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
     puts "Error: Invalid version format '#{version}'"
-    puts "Expected semantic versioning format: X.Y.Z"
+    puts "Expected semantic versioning format: X.Y.Z[-PRERELEASE]"
     exit 1
   end
 

--- a/scripts/update_checksums.rb
+++ b/scripts/update_checksums.rb
@@ -125,9 +125,11 @@ end
 
 version = ARGV[0]
 
-# Validate semantic versioning format (X.Y.Z)
-unless version =~ /^\d+\.\d+\.\d+$/
-  puts "Error: Version '#{version}' is not in semantic versioning format (X.Y.Z)"
+# Validate semantic versioning format. Accept an optional SemVer pre-release
+# suffix like "9.0.0-1" so wrapper repackages can ship under a tag that
+# differs from the upstream MLKit version.
+unless version =~ /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
+  puts "Error: Version '#{version}' is not in semantic versioning format (X.Y.Z[-PRERELEASE])"
   exit 1
 end
 begin

--- a/scripts/update_readme.rb
+++ b/scripts/update_readme.rb
@@ -62,9 +62,10 @@ end
 
 new_version = ARGV[0]
 
-# Validate semantic versioning format (X.Y.Z)
-unless new_version =~ /^\d+\.\d+\.\d+$/
-  puts "Error: Version '#{new_version}' is not in semantic versioning format (X.Y.Z)"
+# Validate semantic versioning format. Accept an optional SemVer pre-release
+# suffix (e.g. "9.0.0-1") for wrapper repackages.
+unless new_version =~ /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
+  puts "Error: Version '#{new_version}' is not in semantic versioning format (X.Y.Z[-PRERELEASE])"
   exit 1
 end
 

--- a/scripts/update_version.rb
+++ b/scripts/update_version.rb
@@ -3,15 +3,18 @@
 
 require 'fileutils'
 
-# Update Podfile with new MLKit version
+# Update Podfile with new MLKit version. The Podfile tracks the upstream
+# CocoaPods version, so a wrapper-only pre-release (e.g. "9.0.0-1") must
+# write the base "9.0.0" pod constraint, not the suffixed string.
 def update_podfile(new_version)
+  pod_version = new_version.sub(/-.*\z/, '')
   podfile = File.read('Podfile')
   updated = podfile.gsub(
     /pod\s+'GoogleMLKit\/(FaceDetection|BarcodeScanning|TextRecognition|TextRecognitionChinese|TextRecognitionDevanagari|TextRecognitionJapanese|TextRecognitionKorean|ImageLabeling|ImageLabelingCustom|ObjectDetection|ObjectDetectionCustom|PoseDetection|PoseDetectionAccurate|SegmentationSelfie|LanguageID|Translate|SmartReply)',\s+'~>\s+[0-9]+(?:\.[0-9]+)*'/,
-    "pod 'GoogleMLKit/\\1', '~> #{new_version}'"
+    "pod 'GoogleMLKit/\\1', '~> #{pod_version}'"
   )
   File.write('Podfile', updated)
-  puts "Updated Podfile to version #{new_version}"
+  puts "Updated Podfile to version #{pod_version}"
 end
 
 # Parse Podfile.lock to extract framework versions
@@ -115,9 +118,11 @@ end
 
 new_version = ARGV[0]
 
-# Validate semantic versioning format (X.Y.Z)
-unless new_version =~ /^\d+\.\d+\.\d+$/
-  puts "Error: Version '#{new_version}' is not in semantic versioning format (X.Y.Z)"
+# Validate semantic versioning format. Accept an optional SemVer pre-release
+# suffix like "9.0.0-1" so wrapper-only repackages can ship without colliding
+# with the upstream MLKit tag of the same base version.
+unless new_version =~ /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
+  puts "Error: Version '#{new_version}' is not in semantic versioning format (X.Y.Z[-PRERELEASE])"
   exit 1
 end
 

--- a/scripts/upload_release.sh
+++ b/scripts/upload_release.sh
@@ -11,10 +11,12 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-# Validate version format (semantic versioning: X.Y.Z)
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+# Validate version format. Accept an optional SemVer pre-release suffix
+# (e.g. "9.0.0-1") so wrapper repackages can ship with a tag distinct from
+# the upstream MLKit base version.
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
   echo "Error: Invalid version format '$VERSION'"
-  echo "Expected semantic versioning format: X.Y.Z (e.g., 1.2.3, 2.0.0)"
+  echo "Expected semantic versioning format: X.Y.Z[-PRERELEASE] (e.g., 1.2.3, 9.0.0-1)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Loosens version validation in every release-flow script to accept an optional SemVer pre-release suffix (e.g. `9.0.0-1`), so a wrapper-only repackage of an existing upstream MLKit version can ship under a fresh tag without overwriting the original.
- `update_version.rb` now strips the suffix before rewriting `Podfile` pod constraints, so a wrapper tag like `9.0.0-1` still produces `pod 'GoogleMLKit/...', '~> 9.0.0'`.
- Files touched: `scripts/{build_all,upload_release,create_release,automate_release}.sh`, `scripts/{update_version,update_checksums,generate_release_notes,update_readme}.rb`.

## Why

Issue #90 surfaced an App-Store-illegal `CFBundleShortVersionString` baked into the `9.0.0` Release zips. PR #94 fixed the templates and the regen logic on `main`, but to ship the fix to consumers we need to publish a new XCFramework bundle. Overwriting the existing `9.0.0` tag would force every downstream `Package.resolved` to refetch and would break checksum pinning. Tagging `9.0.0-1` (SemVer pre-release) keeps the original `9.0.0` immutable: SwiftPM `from: "9.0.0"` excludes pre-release tags, so existing consumers are unaffected, and AppStore-blocked consumers can opt in via `from: "9.0.0-1"` once the release exists.

## Note on the workflow file

`build-mlkit.yml` could also be improved (auto `prerelease: true` when the version contains `-`, plus an updated input description), but pushing workflow file changes requires the `workflow` OAuth scope which the local `gh` token lacks. That follow-up is intentionally left out of this PR; the existing workflow already works with `9.0.0-1` because it just forwards the input to the now-permissive scripts.

## Test plan

- [x] `ruby -c` / `bash -n` on every modified script
- [x] Verified `^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$` accepts `9.0.0`, `9.0.0-1`, `9.0.0-rc.1` and rejects `9.0.0-`, `9.0`, `v9.0.0`
- [x] Verified `update_podfile` writes `~> 9.0.0` whether passed `9.0.0` or `9.0.0-1`
- [ ] Trigger `Build MLKit XCFrameworks` workflow with `version=9.0.0-1`, confirm tag `9.0.0-1` is created (without touching the existing `9.0.0` tag) and a pre-release GitHub Release is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)