### PR TITLE
Initialize xcframework-maker submodule in bootstrap-builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ bootstrap-cocoapods:
 	@bundle exec pod install
 
 bootstrap-builder:
+	@git submodule update --init --recursive xcframework-maker
 	@cd xcframework-maker && swift build -c release
 
 build-cocoapods: bootstrap-cocoapods


### PR DESCRIPTION
## Summary

Run \`git submodule update --init --recursive xcframework-maker\` before \`swift build\` in the \`bootstrap-builder\` Makefile target so the build works regardless of whether the checkout initialized submodules.

## Why

The \`Build MLKit XCFrameworks\` workflow uses \`actions/checkout@v6\` without \`submodules: true\`, so \`xcframework-maker/\` lands as an empty directory in CI. The Makefile's \`bootstrap-builder\` then runs \`cd xcframework-maker && swift build -c release\` — with no \`Package.swift\` in CWD, SwiftPM walks up to the repo root, picks up the parent \`Package.swift\`, and fails on platform inference:

\`\`\`
error: the library 'Common' requires macos 10.13, but depends on the product 'GULAppDelegateSwizzler' which requires macos 10.15
\`\`\`

This blocked the \`9.0.0-1\` repackage build (run [25205994790](https://github.com/d-date/google-mlkit-swiftpm/actions/runs/25205994790)).

The fix runs the submodule init inside the Makefile so it is idempotent: harmless when the submodule is already checked out, sufficient when it isn't. As a side benefit, fresh local clones no longer need the README-mandated \`git submodule update --init\` step before \`make run\`.

A more "proper" fix is to add \`submodules: true\` to \`actions/checkout@v6\` in \`build-mlkit.yml\`, but that requires the \`workflow\` OAuth scope; this Makefile change is scope-agnostic.

Refs #90

## Test plan

- [x] \`make bootstrap-builder\` is idempotent (re-running does not re-clone)
- [ ] After merge: re-run the \`Build MLKit XCFrameworks\` workflow with \`version=9.0.0-1\` and confirm \`bootstrap-builder\` succeeds and the build proceeds to \`build-cocoapods\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)