### PR TITLE
WIP: fix text recognition 'Invalid model path' — bundle placement (#106)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,22 @@ create-xcframework: bootstrap-builder build-cocoapods prepare-info-plist
 copy-resource-bundle:
 	@cp -rf "./Pods/MLKitFaceDetection/Frameworks/MLKitFaceDetection.framework/GoogleMVFaceDetectorResources.bundle" "./GoogleMLKit/GoogleMVFaceDetectorResources.bundle"
 
-archive: create-xcframework copy-resource-bundle
+# Text recognition resolves its OCR model via -[MLKTextRecognizer initWithLogger:options:],
+# which lives in MLKitTextRecognitionCommon and looks the bundle up with [NSBundle bundleForClass:].
+# So LatinOCRResources.bundle must sit INSIDE MLKitTextRecognitionCommon.framework, not be shipped
+# as a sibling top-level .bundle (that never gets found). The pod ships the raw model files under
+# Pods/MLKitTextRecognition/Resources/LatinOCRResources; assemble them into a .bundle and embed it
+# into every slice of the produced xcframework. See issue #106.
+embed-text-recognition-resources:
+	@for SLICE in ios-arm64 ios-x86_64-simulator; do \
+		BUNDLE="./GoogleMLKit/MLKitTextRecognitionCommon.xcframework/$$SLICE/MLKitTextRecognitionCommon.framework/LatinOCRResources.bundle"; \
+		rm -rf "$$BUNDLE"; \
+		mkdir -p "$$BUNDLE"; \
+		cp -rf "./Pods/MLKitTextRecognition/Resources/LatinOCRResources/." "$$BUNDLE/"; \
+		cp -f "./Resources/LatinOCRResources-Info.plist" "$$BUNDLE/Info.plist"; \
+	done
+
+archive: create-xcframework copy-resource-bundle embed-text-recognition-resources
 	@cd ./GoogleMLKit/MLKitBarcodeScanning.xcframework/ios-arm64/MLKitBarcodeScanning.framework \
 	 && mv MLKitBarcodeScanning MLKitBarcodeScanning.o \
 	 && ar r MLKitBarcodeScanning MLKitBarcodeScanning.o \

--- a/Resources/LatinOCRResources-Info.plist
+++ b/Resources/LatinOCRResources-Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.cocoapods.LatinOCRResources</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>LatinOCRResources</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
> **Draft / needs a maintainer decision.** After shipping a fix to the App Store I realised this PR, as written, matches *neither* of the two coherent fixes cleanly. Keeping it open as a starting point — happy to rework toward whichever route you prefer. Details in [#106 (UPDATE comment)](https://github.com/d-date/google-mlkit-swiftpm/issues/106#issuecomment-4727945565).

Re: #106 — `TextRecognizer` creation crashes with `MLKTextRecognizerInternalErrorCreationFailure: 'Invalid model path.'`

## The crux: static vs dynamic decides where the bundle must live

`-[MLKTextRecognizer initWithLogger:options:]` lives in `MLKitTextRecognitionCommon` and resolves its OCR model via `[NSBundle bundleForClass:]`. **Where that resolves depends on how Common is linked:**

- **Static `MH_OBJECT` (what this repo ships today)** → Common is linked into the app executable, *not* embedded → `bundleForClass:` → **app main bundle**.
- **Dynamic `MH_DYLIB`** → Common is an embedded `App.app/Frameworks/MLKitTextRecognitionCommon.framework` → `bundleForClass:` → **that framework**.

In both cases the released `MLKitTextRecognitionCommon.xcframework` simply has **no OCR model** — the `MLKitTextRecognition` pod ships the raw files under `Pods/MLKitTextRecognition/Resources/LatinOCRResources/`, but nothing assembles them into `LatinOCRResources.bundle` or delivers it.

## Two coherent fixes (your call)

**(A) Keep Common static** — publish `LatinOCRResources.bundle` as a top-level `.bundle.zip` release asset and document that consumers add it to their app target, exactly like `GoogleMVFaceDetectorResources.bundle`. `bundleForClass:` → main bundle → found. Smallest change, matches your existing pattern. *(I have not runtime-tested this path, but the mechanism supports it.)*

**(B) Make Common dynamic** — relink the object to a dylib in the pipeline, embed `LatinOCRResources.bundle` inside `MLKitTextRecognitionCommon.framework`, **and set that framework's `Info.plist` `MinimumOSVersion` to match the binary's `minos` (15.5)**, or the App Store rejects the embedded framework with **ITMS-90208**. This is what I run in production. *(verified end-to-end on device + simulator.)*

## What this PR currently contains

A new `embed-text-recognition-resources` Make target that assembles `LatinOCRResources.bundle` from the pod's raw resources (+ a CocoaPods-style `Info.plist`) and copies it **inside** `MLKitTextRecognitionCommon.framework` during `archive`, plus a `Resources/LatinOCRResources-Info.plist` template.

⚠️ This is the bundle-embed half of **(B)** but **without** the relink and **without** the `MinimumOSVersion` alignment — and since Common stays static here, the embedded-in-framework bundle won't be found via `bundleForClass:` (which points at the main bundle for static linkage). So this diff alone likely does **not** fix the crash. It needs to be reworked toward (A) or completed toward (B), and verified via a `build-mlkit` dispatch (I can't run that workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)